### PR TITLE
Define exports.types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
     "require": "./dist/index.cjs",
-    "import": "./dist/index.mjs"
+    "import": "./dist/index.mjs",
+    "types": "./dist/index.d.ts"
   },
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
`exports.types` in `package.json` is currently missing.

This prevents some bundlers (tested with vite/sveltekit) from properly finding the types for this package despite the `types` property.

If anyone else is running into this problem, I've aliased `poline` to the ts file directly in my vite config as a hacky work around. Here's my config:
```
{
	resolve: {
		alias: {
			poline: './node_modules/poline/src/index.ts',
		},
	},
	...
}
```